### PR TITLE
bugfix: 노트 생성 오류 수정(#1)

### DIFF
--- a/server/src/main/kotlin/work/notespace/server/note/repository/NoteRepository.kt
+++ b/server/src/main/kotlin/work/notespace/server/note/repository/NoteRepository.kt
@@ -10,4 +10,5 @@ interface NoteRepository : JpaRepository<Note, String> {
     fun findBySlug(slug: String): Note?
     fun findAllByOrderByCreatedAtDesc(pageRequest: Pageable): List<Note>
     fun findAllByOrderByUpdatedAtDesc(pageRequest: Pageable): List<Note>
+    fun existsBySlug(slug: String): Boolean
 }

--- a/server/src/main/kotlin/work/notespace/server/note/service/NoteService.kt
+++ b/server/src/main/kotlin/work/notespace/server/note/service/NoteService.kt
@@ -28,6 +28,10 @@ class NoteService(
 
     @Transactional
     fun createNote(req: NoteDto): NoteDto {
+        if (noteRepository.existsBySlug(req.slug)) {
+            throw IllegalArgumentException("A note with slug='${req.slug}' already exists")
+        }
+
         val note = Note(
             slug = req.slug,
             name = req.name,


### PR DESCRIPTION
save의 이중성(insert or update) 해결을 위해 이미 PK가 중복되지 않는 조건에서 save, 즉 insert만 허용